### PR TITLE
Allow duplicate keys in yml file

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -55,7 +55,7 @@ function readFile(filename, callback) {
             result = _json52['default'].parse(data);
             break;
           case '.yml':
-            result = _jsYaml2['default'].safeLoad(data);
+            result = _jsYaml2['default'].safeLoad(data, { json: true });
             break;
           default:
             result = JSON.parse(data);

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ function readFile(filename, callback) {
             result = JSON5.parse(data);
             break;
           case '.yml':
-            result = YAML.safeLoad(data);
+            result = YAML.safeLoad(data, { json: true });
             break;
           default:
             result = JSON.parse(data);


### PR DESCRIPTION
For some reason. We have duplicate keys in our yml locale files.
And there is no bad effect if we open this option I think.