### PR TITLE
Add support to use javascript and typescript files as resource files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,31 +43,44 @@ function getDefaults() {
 }
 
 function readFile(filename, callback) {
-  _fs2['default'].readFile(filename, 'utf8', function (err, data) {
-    if (err) {
-      callback(err);
-    } else {
-      var result = undefined;
-      try {
-        data = data.replace(/^\uFEFF/, '');
-        switch (_path2['default'].extname(filename)) {
-          case '.json5':
-            result = _json52['default'].parse(data);
-            break;
-          case '.yml':
-          case '.yaml':
-            result = _jsYaml2['default'].safeLoad(data);
-            break;
-          default:
-            result = JSON.parse(data);
-        }
-      } catch (err) {
-        err.message = 'error parsing ' + filename + ': ' + err.message;
-        return callback(err);
-      }
-      callback(null, result);
+  var extension = _path2['default'].extname(filename);
+  var result = undefined;
+
+  if (/^\.(js|ts)$/.test(extension)) {
+    var file = require(filename);
+    result = file['default'] ? file['default'] : file;
+
+    if (typeof result !== 'object') {
+      return callback(new Error('A resource file must export an object.'));
     }
-  });
+
+    callback(null, result);
+  } else {
+    _fs2['default'].readFile(filename, 'utf8', function (err, data) {
+      if (err) {
+        callback(err);
+      } else {
+        try {
+          data = data.replace(/^\uFEFF/, '');
+          switch (extension) {
+            case '.json5':
+              result = _json52['default'].parse(data);
+              break;
+            case '.yml':
+            case '.yaml':
+              result = _jsYaml2['default'].safeLoad(data);
+              break;
+            default:
+              result = JSON.parse(data);
+          }
+        } catch (err) {
+          err.message = 'error parsing ' + filename + ': ' + err.message;
+          return callback(err);
+        }
+        callback(null, result);
+      }
+    });
+  }
 }
 
 var Backend = (function () {

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,14 +47,18 @@ function readFile(filename, callback) {
   var result = undefined;
 
   if (/^\.(js|ts)$/.test(extension)) {
-    var file = require(filename);
-    result = file['default'] ? file['default'] : file;
+    try {
+      var file = require(filename);
+      result = file['default'] ? file['default'] : file;
 
-    if (typeof result !== 'object') {
-      return callback(new Error('A resource file must export an object.'));
+      if (typeof result !== 'object') {
+        return callback(new Error('A resource file must export an object.'));
+      }
+
+      callback(null, result);
+    } catch (err) {
+      callback(err);
     }
-
-    callback(null, result);
   } else {
     _fs2['default'].readFile(filename, 'utf8', function (err, data) {
       if (err) {

--- a/src/index.js
+++ b/src/index.js
@@ -17,14 +17,18 @@ function readFile(filename, callback) {
   let result;
 
   if (/^\.(js|ts)$/.test(extension)) {
-    const file = require(filename);
-    result = file.default ? file.default : file;
+    try {
+      const file = require(filename);
+      result = file.default ? file.default : file;
 
-    if (typeof result !== 'object') {
-      return callback(new Error('A resource file must export an object.'));
+      if (typeof result !== 'object') {
+        return callback(new Error('A resource file must export an object.'));
+      }
+
+      callback(null, result);
+    } catch (err) {
+      callback(err);
     }
-
-    callback(null, result);
   } else {
     fs.readFile(filename, 'utf8', function(err, data) {
       if (err) {

--- a/test/backend.js
+++ b/test/backend.js
@@ -1,5 +1,6 @@
 var mockery = require('mockery');
 var expect = require('chai').expect;
+var path = require('path');
 
 var Interpolator = require('i18next/dist/commonjs/Interpolator').default;
 
@@ -39,13 +40,14 @@ var fsMock = {
 
 
 describe('backend', function() {
+  var Backend;
   var backend;
 
   before(function() {
     mockery.enable();
     mockery.registerMock('fs', fsMock);
 
-    var Backend = require('../lib');
+    Backend = require('../lib');
     backend = new Backend({
       interpolator: new Interpolator()
     }, {
@@ -65,6 +67,33 @@ describe('backend', function() {
     });
   });
 
+  it('read javascript files', function(done) {
+    backend = new Backend({
+      interpolator: new Interpolator()
+    }, {
+      loadPath: path.join(__dirname, '/locales/{{lng}}/{{ns}}.js')
+    });
+
+    backend.read('en', 'test', function(err, data) {
+      expect(err).to.be.not.ok;
+      expect(data).to.eql({key: 'passing', evaluated: 2});
+      done();
+    });
+  });
+
+  it('fail if a bad js file is provided', function(done) {
+    backend = new Backend({
+      interpolator: new Interpolator()
+    }, {
+      loadPath: path.join(__dirname, '/locales/{{lng}}/{{ns}}.js')
+    });
+
+    backend.read('en', 'bad', function(err, data) {
+      expect(err).to.be.ok;
+      expect(data).to.eql(false);
+      done();
+    });
+  });
 
   it('create simple', function(done) {
     backend.create('en', 'test', 'some.key', 'myDefault', function() {

--- a/test/locales/en/bad.js
+++ b/test/locales/en/bad.js
@@ -1,0 +1,1 @@
+module.exports = 'randomString';

--- a/test/locales/en/test.js
+++ b/test/locales/en/test.js
@@ -1,0 +1,4 @@
+module.exports = {
+  key: 'passing',
+  evaluated: 1 + 1
+};


### PR DESCRIPTION
# Changes
- Now javascript files can be used as resource files, reading the default exported object.
- Also in theory, typescript files should be supported while using tools like ts-node.

#### This PR has no breaking changes.