### PR TITLE
fix: parse option is called only when format is unknown

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,8 +16,17 @@ function getDefaults() {
 function readFile(filename, options, callback) {
   const extension = path.extname(filename);
   let result;
-
-  if (/^\.(js|ts)$/.test(extension)) {
+  if (options.parse) {
+    try {
+      result = options.parse(data);
+      if (typeof result !== 'object') {
+        return callback(new Error('A resource file must export an object.'));
+      }
+      callback(null, result);
+    } catch (err) {
+      callback(err);
+    }
+  } else if (/^\.(js|ts)$/.test(extension)) {
     try {
       const file = require(filename);
       result = file.default ? file.default : file;

--- a/test/backend.js
+++ b/test/backend.js
@@ -1,6 +1,7 @@
 var mockery = require('mockery');
 var expect = require('chai').expect;
 var path = require('path');
+var sinon = require('sinon');
 
 var Interpolator = require('i18next/dist/commonjs/Interpolator').default;
 
@@ -128,6 +129,21 @@ describe('backend', function() {
     backend.create(['en', 'de'], 'test4', 'key3', '3')
     backend.create(['en', 'de'], 'test4', 'key4', '4', function() {
       expect(test4Save).to.equal(2);
+      done();
+    });
+  });
+
+  it.only('calls custom parse function if it is passed', function(done) {
+    const parseStub = sinon.stub().returns({key: 'passing', evaluated: 2})
+    backend = new Backend({
+      interpolator: new Interpolator()
+    }, {
+      loadPath: path.join(__dirname, '/locales/{{lng}}/{{ns}}.json'),
+      parse: parseStub
+    });
+
+    backend.read('en', 'test', function(err, data) {
+      expect(parseStub.callCount).to.equal(1)
       done();
     });
   });


### PR DESCRIPTION
Pull request to close an issue:
https://github.com/i18next/i18next-node-fs-backend/issues/240